### PR TITLE
fix: guard UiMaterialPlugin registration against duplicate add

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,19 +92,22 @@ impl<T: Transitionalbe> Plugin for MenuTransitionPlugin<T> {
         app.insert_resource(MenuTransitionSettings::<T> {
             mask_stretch_mode: self.mask_stretch_mode,
             marker: PhantomData,
-        })
-        .add_plugins(UiMaterialPlugin::<MenuTransitionMaterial>::default())
-        .init_state::<TransitionState>()
-        .add_message::<TriggerMenuTransition<T>>()
-        .add_systems(
-            Last,
-            (
-                idle::<T>.run_if(in_state(TransitionState::Idle)),
-                create_material::<T>.run_if(in_state(TransitionState::TakingScreenshot)),
-                wait_for_assets::<T>.run_if(in_state(TransitionState::LoadingMaskAndScreenshot)),
-                despawn.run_if(in_state(TransitionState::Transitioning)),
-            ),
-        );
+        });
+        if !app.is_plugin_added::<UiMaterialPlugin<MenuTransitionMaterial>>() {
+            app.add_plugins(UiMaterialPlugin::<MenuTransitionMaterial>::default());
+        }
+        app.init_state::<TransitionState>()
+            .add_message::<TriggerMenuTransition<T>>()
+            .add_systems(
+                Last,
+                (
+                    idle::<T>.run_if(in_state(TransitionState::Idle)),
+                    create_material::<T>.run_if(in_state(TransitionState::TakingScreenshot)),
+                    wait_for_assets::<T>
+                        .run_if(in_state(TransitionState::LoadingMaskAndScreenshot)),
+                    despawn.run_if(in_state(TransitionState::Transitioning)),
+                ),
+            );
         embedded_asset!(app, "transition.wgsl");
     }
 }


### PR DESCRIPTION
## Problem

`MenuTransitionPlugin<T>` is generic over a state type, making it natural to register multiple times -- once per state type driving transitions. For example, a game might use one instance for top-level `AppState` menu wipes and a second for an inner `InGameSubState` biome wipe.

Previously, `build()` called `add_plugins(UiMaterialPlugin::<MenuTransitionMaterial>::default())` unconditionally, so the second registration panicked:

```
Error adding plugin UiMaterialPlugin<MenuTransitionMaterial>:
plugin was already added in application
```

## Fix

Check `app.is_plugin_added::<UiMaterialPlugin<MenuTransitionMaterial>>()` before registering, so the UI material pipeline is set up exactly once regardless of how many state-typed variants the application adds.

```rust
if !app.is_plugin_added::<UiMaterialPlugin<MenuTransitionMaterial>>() {
    app.add_plugins(UiMaterialPlugin::<MenuTransitionMaterial>::default());
}
```

## Test plan

- [x] Verify a project that registers `MenuTransitionPlugin<StateA>` and `MenuTransitionPlugin<StateB>` in the same `App` no longer panics on startup
- [x] Verify transitions still work correctly with a single registration (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)